### PR TITLE
Being able to inject RequestConfig with CDI

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/config/RequestConfig.java
+++ b/httpclient/src/main/java/org/apache/http/client/config/RequestConfig.java
@@ -60,6 +60,14 @@ public class RequestConfig implements Cloneable {
     private final int socketTimeout;
     private final boolean decompressionEnabled;
 
+    /**
+     * CDI eyes only
+     * @deprecated CDI eyes only
+    */
+    public RequestConfig() {
+		this(false, null, null, false, null, false, false, false, 0, false, null, null, 0, 0, 0, false);
+    }
+    
     RequestConfig(
             final boolean expectContinueEnabled,
             final HttpHost proxy,

--- a/httpclient/src/main/java/org/apache/http/client/config/RequestConfig.java
+++ b/httpclient/src/main/java/org/apache/http/client/config/RequestConfig.java
@@ -64,7 +64,7 @@ public class RequestConfig implements Cloneable {
      * CDI eyes only
      * @deprecated CDI eyes only
     */
-    public RequestConfig() {
+    protected RequestConfig() {
 		this(false, null, null, false, null, false, false, false, 0, false, null, null, 0, 0, 0, false);
     }
     


### PR DESCRIPTION
CDI specification requires default constructor to being able to inject the bean.

Since CDI is a Oracle specification and is getting used even more, I believe `httpclient` should support it.
This PR adds a default constructor to `RequestConfig` class, allowing it to be injected with CDI.