### PR TITLE
Provide convenience functions for constructing the default cookie spec r...

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/client/CookieSpecRegistries.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/CookieSpecRegistries.java
@@ -1,0 +1,83 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.impl.client;
+
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.util.PublicSuffixMatcher;
+import org.apache.http.conn.util.PublicSuffixMatcherLoader;
+import org.apache.http.cookie.CookieSpecProvider;
+import org.apache.http.impl.cookie.DefaultCookieSpecProvider;
+import org.apache.http.impl.cookie.IgnoreSpecProvider;
+import org.apache.http.impl.cookie.NetscapeDraftSpecProvider;
+import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
+
+public final class CookieSpecRegistries {
+    /**
+     * Creates the default registry, using the default public suffix matcher.
+     */
+    public static Lookup<CookieSpecProvider> createDefault() {
+        return createDefault(PublicSuffixMatcherLoader.getDefault());
+    }
+
+    /**
+     * Creates a builder containing the default registry entries, using the provided public suffix matcher.
+     */
+    public static RegistryBuilder<CookieSpecProvider> defaultBuilder(final PublicSuffixMatcher publicSuffixMatcher) {
+        final CookieSpecProvider defaultProvider = new DefaultCookieSpecProvider(publicSuffixMatcher);
+        final CookieSpecProvider laxStandardProvider = new RFC6265CookieSpecProvider(
+                RFC6265CookieSpecProvider.CompatibilityLevel.RELAXED, publicSuffixMatcher);
+        final CookieSpecProvider strictStandardProvider = new RFC6265CookieSpecProvider(
+                RFC6265CookieSpecProvider.CompatibilityLevel.STRICT, publicSuffixMatcher);
+        return RegistryBuilder.<CookieSpecProvider>create()
+                .register(CookieSpecs.DEFAULT, defaultProvider)
+                .register("best-match", defaultProvider)
+                .register("compatibility", defaultProvider)
+                .register(CookieSpecs.STANDARD, laxStandardProvider)
+                .register(CookieSpecs.STANDARD_STRICT, strictStandardProvider)
+                .register(CookieSpecs.NETSCAPE, new NetscapeDraftSpecProvider())
+                .register(CookieSpecs.IGNORE_COOKIES, new IgnoreSpecProvider());
+    }
+
+    /**
+     * Creates a builder without any default cookie spec providers
+     */
+    public static RegistryBuilder<CookieSpecProvider> empty() {
+        return RegistryBuilder.create();
+    }
+
+    /**
+     * Creates the default registry with the provided public suffix matcher
+     */
+    public static Lookup<CookieSpecProvider> createDefault(final PublicSuffixMatcher publicSuffixMatcher) {
+        return defaultBuilder(publicSuffixMatcher).build();
+    }
+
+    private CookieSpecRegistries() {}
+}

--- a/httpclient/src/main/java/org/apache/http/impl/client/HttpClientBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/HttpClientBuilder.java
@@ -59,7 +59,6 @@ import org.apache.http.client.RedirectStrategy;
 import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.client.UserTokenHandler;
 import org.apache.http.client.config.AuthSchemes;
-import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.InputStreamFactory;
 import org.apache.http.client.protocol.RequestAcceptEncoding;
@@ -99,10 +98,6 @@ import org.apache.http.impl.conn.DefaultRoutePlanner;
 import org.apache.http.impl.conn.DefaultSchemePortResolver;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
-import org.apache.http.impl.cookie.DefaultCookieSpecProvider;
-import org.apache.http.impl.cookie.IgnoreSpecProvider;
-import org.apache.http.impl.cookie.NetscapeDraftSpecProvider;
-import org.apache.http.impl.cookie.RFC6265CookieSpecProvider;
 import org.apache.http.impl.execchain.BackoffStrategyExec;
 import org.apache.http.impl.execchain.ClientExecChain;
 import org.apache.http.impl.execchain.MainClientExec;
@@ -735,6 +730,9 @@ public class HttpClientBuilder {
      * Assigns default {@link org.apache.http.cookie.CookieSpec} registry which will
      * be used for request execution if not explicitly set in the client execution
      * context.
+     *
+     * @see org.apache.http.impl.client.CookieSpecRegistries
+     *
      */
     public final HttpClientBuilder setDefaultCookieSpecRegistry(
             final Lookup<CookieSpecProvider> cookieSpecRegistry) {
@@ -1172,20 +1170,7 @@ public class HttpClientBuilder {
         }
         Lookup<CookieSpecProvider> cookieSpecRegistryCopy = this.cookieSpecRegistry;
         if (cookieSpecRegistryCopy == null) {
-            final CookieSpecProvider defaultProvider = new DefaultCookieSpecProvider(publicSuffixMatcherCopy);
-            final CookieSpecProvider laxStandardProvider = new RFC6265CookieSpecProvider(
-                    RFC6265CookieSpecProvider.CompatibilityLevel.RELAXED, publicSuffixMatcherCopy);
-            final CookieSpecProvider strictStandardProvider = new RFC6265CookieSpecProvider(
-                    RFC6265CookieSpecProvider.CompatibilityLevel.STRICT, publicSuffixMatcherCopy);
-            cookieSpecRegistryCopy = RegistryBuilder.<CookieSpecProvider>create()
-                .register(CookieSpecs.DEFAULT, defaultProvider)
-                .register("best-match", defaultProvider)
-                .register("compatibility", defaultProvider)
-                .register(CookieSpecs.STANDARD, laxStandardProvider)
-                .register(CookieSpecs.STANDARD_STRICT, strictStandardProvider)
-                .register(CookieSpecs.NETSCAPE, new NetscapeDraftSpecProvider())
-                .register(CookieSpecs.IGNORE_COOKIES, new IgnoreSpecProvider())
-                .build();
+            cookieSpecRegistryCopy = CookieSpecRegistries.createDefault(publicSuffixMatcherCopy);
         }
 
         CookieStore defaultCookieStore = this.cookieStore;

--- a/httpclient/src/main/java/org/apache/http/impl/cookie/DefaultCookieSpec.java
+++ b/httpclient/src/main/java/org/apache/http/impl/cookie/DefaultCookieSpec.java
@@ -44,7 +44,7 @@ import org.apache.http.util.Args;
 import org.apache.http.util.CharArrayBuffer;
 
 /**
- * Default cookie specification that picks up the bests matching cookie policy based on
+ * Default cookie specification that picks up the best matching cookie policy based on
  * the format of cookies sent with the HTTP response.
  *
  * @since 4.4

--- a/httpclient/src/main/java/org/apache/http/impl/cookie/DefaultCookieSpec.java
+++ b/httpclient/src/main/java/org/apache/http/impl/cookie/DefaultCookieSpec.java
@@ -68,7 +68,6 @@ public class DefaultCookieSpec implements CookieSpec {
     public DefaultCookieSpec(
             final String[] datepatterns,
             final boolean oneHeader) {
-        super();
         this.strict = new RFC2965Spec(oneHeader,
                 new RFC2965VersionAttributeHandler(),
                 new BasicPathHandler(),


### PR DESCRIPTION
...egistry and to build on top of the default entries.

Use them to construct the default registry from HttpClientBuilder when no cookie spec registry has been provided.

This allows clients to easily add their own CookieSpecProviders without having to duplicate the list of defaults.

Two further entirely cosmetic changes followed.