### PR TITLE
Cache request line in HttpRequestWrapper

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/methods/HttpRequestWrapper.java
+++ b/httpclient/src/main/java/org/apache/http/client/methods/HttpRequestWrapper.java
@@ -109,7 +109,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     @Override
     public RequestLine getRequestLine() {
-        if (cachedRequestLine == null) {
+        if (this.cachedRequestLine == null) {
             String requestUri = null;
             if (this.uri != null) {
                 requestUri = this.uri.toASCIIString();
@@ -119,9 +119,9 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
             if (requestUri == null || requestUri.isEmpty()) {
                 requestUri = "/";
             }
-            cachedRequestLine = new BasicRequestLine(this.method, requestUri, getProtocolVersion());
+            this.cachedRequestLine = new BasicRequestLine(this.method, requestUri, getProtocolVersion());
         }
-        return cachedRequestLine;
+        return this.cachedRequestLine;
     }
 
     public HttpRequest getOriginal() {

--- a/httpclient/src/main/java/org/apache/http/client/methods/HttpRequestWrapper.java
+++ b/httpclient/src/main/java/org/apache/http/client/methods/HttpRequestWrapper.java
@@ -54,6 +54,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
     private final HttpRequest original;
     private final HttpHost target;
     private final String method;
+    private RequestLine cachedRequestLine = null;
     private ProtocolVersion version;
     private URI uri;
 
@@ -78,6 +79,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     public void setProtocolVersion(final ProtocolVersion version) {
         this.version = version;
+        cachedRequestLine = null;
     }
 
     @Override
@@ -87,6 +89,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     public void setURI(final URI uri) {
         this.uri = uri;
+        cachedRequestLine = null;
     }
 
     @Override
@@ -106,16 +109,19 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     @Override
     public RequestLine getRequestLine() {
-        String requestUri = null;
-        if (this.uri != null) {
-            requestUri = this.uri.toASCIIString();
-        } else {
-            requestUri = this.original.getRequestLine().getUri();
+        if (cachedRequestLine == null) {
+            String requestUri = null;
+            if (this.uri != null) {
+                requestUri = this.uri.toASCIIString();
+            } else {
+                requestUri = this.original.getRequestLine().getUri();
+            }
+            if (requestUri == null || requestUri.isEmpty()) {
+                requestUri = "/";
+            }
+            cachedRequestLine = new BasicRequestLine(this.method, requestUri, getProtocolVersion());
         }
-        if (requestUri == null || requestUri.isEmpty()) {
-            requestUri = "/";
-        }
-        return new BasicRequestLine(this.method, requestUri, getProtocolVersion());
+        return cachedRequestLine;
     }
 
     public HttpRequest getOriginal() {

--- a/httpclient/src/main/java/org/apache/http/client/methods/HttpRequestWrapper.java
+++ b/httpclient/src/main/java/org/apache/http/client/methods/HttpRequestWrapper.java
@@ -79,7 +79,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     public void setProtocolVersion(final ProtocolVersion version) {
         this.version = version;
-        cachedRequestLine = null;
+        this.cachedRequestLine = null;
     }
 
     @Override
@@ -89,7 +89,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     public void setURI(final URI uri) {
         this.uri = uri;
-        cachedRequestLine = null;
+        this.cachedRequestLine = null;
     }
 
     @Override


### PR DESCRIPTION
For each request HttpAsyncClient calls HttpRequestWrapper.getRequestLine() 8 times during single request execution. For URIs containing non-ASCII characters this causes tons of allocations and completely ruins performance.
According to out tests RequestLine caching successfully addresses the issue with the cost of single long living object.