### PR TITLE
Cache request line in HttpRequestWrapper

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/methods/HttpRequestWrapper.java
+++ b/httpclient/src/main/java/org/apache/http/client/methods/HttpRequestWrapper.java
@@ -56,6 +56,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
     private final HttpRequest original;
     private final HttpHost target;
     private final String method;
+    private RequestLine cachedRequestLine = null;
     private ProtocolVersion version;
     private URI uri;
 
@@ -80,6 +81,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     public void setProtocolVersion(final ProtocolVersion version) {
         this.version = version;
+        this.cachedRequestLine = null;
     }
 
     @Override
@@ -89,6 +91,7 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     public void setURI(final URI uri) {
         this.uri = uri;
+        this.cachedRequestLine = null;
     }
 
     @Override
@@ -108,16 +111,19 @@ public class HttpRequestWrapper extends AbstractHttpMessage implements HttpUriRe
 
     @Override
     public RequestLine getRequestLine() {
-        String requestUri = null;
-        if (this.uri != null) {
-            requestUri = this.uri.toASCIIString();
-        } else {
-            requestUri = this.original.getRequestLine().getUri();
+        if (this.cachedRequestLine == null) {
+            String requestUri = null;
+            if (this.uri != null) {
+                requestUri = this.uri.toASCIIString();
+            } else {
+                requestUri = this.original.getRequestLine().getUri();
+            }
+            if (requestUri == null || requestUri.isEmpty()) {
+                requestUri = "/";
+            }
+            this.cachedRequestLine = new BasicRequestLine(this.method, requestUri, getProtocolVersion());
         }
-        if (requestUri == null || requestUri.isEmpty()) {
-            requestUri = "/";
-        }
-        return new BasicRequestLine(this.method, requestUri, getProtocolVersion());
+        return this.cachedRequestLine;
     }
 
     public HttpRequest getOriginal() {


### PR DESCRIPTION
Copy of https://github.com/apache/httpclient/pull/31 for 4.5.x

For each request HttpAsyncClient calls HttpRequestWrapper.getRequestLine() 8 times during single request execution. For URIs containing non-ASCII characters this causes tons of allocations and completely ruins performance.
According to out tests RequestLine caching successfully addresses the issue with the cost of single long living object.