### PR TITLE
Set socker buffer send/receive sizes from SocketConfig

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/conn/DefaultHttpClientConnectionOperator.java
+++ b/httpclient/src/main/java/org/apache/http/impl/conn/DefaultHttpClientConnectionOperator.java
@@ -120,6 +120,9 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
             sock.setReuseAddress(socketConfig.isSoReuseAddress());
             sock.setTcpNoDelay(socketConfig.isTcpNoDelay());
             sock.setKeepAlive(socketConfig.isSoKeepAlive());
+            sock.setReceiveBufferSize(socketConfig.getRcvBufSize());
+            sock.setSendBufferSize(socketConfig.getSndBufSize());
+
             final int linger = socketConfig.getSoLinger();
             if (linger >= 0) {
                 sock.setSoLinger(true, linger);


### PR DESCRIPTION
We noticed that `DefaultHttpClientConnectionOperator` sets other options from `SocketConfig` but does not set the send/receive buffer sizes.