### PR TITLE
String format fix

### DIFF
--- a/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiProxyConfiguration.java
+++ b/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiProxyConfiguration.java
@@ -135,7 +135,7 @@ public final class OSGiProxyConfiguration implements ProxyConfiguration {
     @Override
     public String toString() {
         return format("ProxyConfiguration [enabled=%s, hostname=%s, port=%s, username=%s, password=%s, proxyExceptions=%s]",
-                      proxyExceptions, enabled, hostname, port, username, password, proxyExceptions);
+                      enabled, hostname, port, username, password, proxyExceptions);
     }
 
 }

--- a/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiProxyConfiguration.java
+++ b/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiProxyConfiguration.java
@@ -27,6 +27,7 @@
 package org.apache.http.osgi.impl;
 
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.apache.http.osgi.impl.PropertiesUtils.to;
 
 import java.util.Dictionary;
@@ -135,7 +136,7 @@ public final class OSGiProxyConfiguration implements ProxyConfiguration {
     @Override
     public String toString() {
         return format("ProxyConfiguration [enabled=%s, hostname=%s, port=%s, username=%s, password=%s, proxyExceptions=%s]",
-                      enabled, hostname, port, username, password, proxyExceptions);
+                      enabled, hostname, port, username, password, asList(proxyExceptions));
     }
 
 }

--- a/httpclient-osgi/src/test/java/org/apache/http/osgi/impl/OSGiProxyConfigurationTest.java
+++ b/httpclient-osgi/src/test/java/org/apache/http/osgi/impl/OSGiProxyConfigurationTest.java
@@ -1,0 +1,35 @@
+package org.apache.http.osgi.impl;
+
+import org.junit.Test;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class OSGiProxyConfigurationTest {
+
+    @Test
+    public void testToString() {
+
+        final Dictionary<String, Object> config = new Hashtable<>();
+        config.put("proxy.enabled", false);
+        config.put("proxy.host", "h");
+        config.put("proxy.port", 1);
+        config.put("proxy.username", "u");
+        config.put("proxy.password", "p");
+        config.put("proxy.exceptions", new String[]{"e"});
+
+        final OSGiProxyConfiguration configuration = new OSGiProxyConfiguration();
+        configuration.update(config);
+
+        final String string = configuration.toString();
+        assertThat(string, containsString("enabled=false"));
+        assertThat(string, containsString("hostname=h"));
+        assertThat(string, containsString("port=1"));
+        assertThat(string, containsString("username=u"));
+        assertThat(string, containsString("password=p"));
+        assertThat(string, containsString("proxyExceptions=[e]"));
+    }
+}


### PR DESCRIPTION
There are two issues in the toString method of OSGiProxyConfiguration
- the number of provided arguments does not match the format string
- the proxyExceptions argument is an array so it will not pretty-print.

This pull request fixes both issues and demonstrates the fix with a JUnit test.

Possible improvement for the JUnit test:
Set access modifier to package for string constants in OSGiProxyConfiguration so I can refer to them in the JUnit test. This would make the test less brittle to (internal) code modifications.

