### PR TITLE
Delete obsolete clone method

### DIFF
--- a/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/CacheEntity.java
+++ b/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/CacheEntity.java
@@ -97,9 +97,4 @@ class CacheEntity implements HttpEntity, Serializable {
     public void consumeContent() throws IOException {
     }
 
-    @Override
-    public Object clone() throws CloneNotSupportedException {
-        return super.clone();
-    }
-
 }


### PR DESCRIPTION
In svn revision 980937 the Cloneable interface was removed from the class CacheEntity but the clone method was not. Assuming the removal of the Cloneable interface was intentional, the clone method should have been removed as well.

See https://fisheye6.atlassian.com/changelog/httpcomponents?cs=980937 for the entire change set.