### PR TITLE
HTTPCLIENT-1710 - fixes - examine all exceptions, correct capture group count

### DIFF
--- a/httpclient-osgi/pom.xml
+++ b/httpclient-osgi/pom.xml
@@ -139,6 +139,11 @@
           <version>${slf4j.version}</version>
           <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiCredentialsProvider.java
+++ b/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiCredentialsProvider.java
@@ -72,7 +72,7 @@ final class OSGiCredentialsProvider implements CredentialsStore {
                 final ProxyConfiguration proxyConfiguration = (ProxyConfiguration) proxyConfigurationObject;
                 if (proxyConfiguration.isEnabled()) {
                     final AuthScope actual = new AuthScope(proxyConfiguration.getHostname(), proxyConfiguration.getPort());
-                    if (authscope.equals(actual)) {
+                    if (authscope.match(actual) >= 12) {
                         final String username = proxyConfiguration.getUsername();
                         final String password = proxyConfiguration.getPassword();
                         return new UsernamePasswordCredentials(username, password != null ? password.toCharArray() : null);

--- a/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiHttpRoutePlanner.java
+++ b/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiHttpRoutePlanner.java
@@ -73,7 +73,7 @@ final class OSGiHttpRoutePlanner extends DefaultRoutePlanner {
     @Override
     protected HttpHost determineProxy(final HttpHost target, final HttpRequest request, final HttpContext context) throws HttpException {
         ProxyConfiguration proxyConfiguration = null;
-
+        HttpHost proxyHost = null;
         for (final ServiceRegistration registration : registeredConfigurations.values()) {
             final Object proxyConfigurationObject = bundleContext.getService(registration.getReference());
             if (proxyConfigurationObject != null) {
@@ -82,15 +82,17 @@ final class OSGiHttpRoutePlanner extends DefaultRoutePlanner {
                     for (final String exception : proxyConfiguration.getProxyExceptions()) {
                         if (createMatcher(exception).matches(target.getHostName())) {
                             return null;
-                        } else {
-                            return new HttpHost(proxyConfiguration.getHostname(), proxyConfiguration.getPort());
                         }
+                    }
+                    if (null == proxyHost)
+                    {
+                        proxyHost = new HttpHost(proxyConfiguration.getHostname(), proxyConfiguration.getPort());
                     }
                 }
             }
         }
 
-        return null;
+        return proxyHost;
     }
 
     private static HostMatcher createMatcher(final String name) {
@@ -174,7 +176,7 @@ final class OSGiHttpRoutePlanner extends DefaultRoutePlanner {
                         final int i4 = toInt(nameMatcher.group(4), 255);
                         final int ip = i1 << 24 | i2 << 16 | i3 << 8 | i4;
 
-                        int mask = toInt(nameMatcher.group(6), 32);
+                        int mask = toInt(nameMatcher.group(4), 32);
                         mask = (mask == 32) ? -1 : -1 - (-1 >>> mask);
 
                         return new NetworkAddress(ip, mask);

--- a/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiProxyConfiguration.java
+++ b/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiProxyConfiguration.java
@@ -63,7 +63,7 @@ public final class OSGiProxyConfiguration implements ProxyConfiguration {
     /**
      * Property representing the username to authenticate with towards the proxy. Defaults to empty.
      */
-    private static final String PROPERTYNAME_PROXY_USERNAME = "proxy.username";
+    private static final String PROPERTYNAME_PROXY_USERNAME = "proxy.user";
 
     private static final String PROPERTYDEFAULT_PROXY_USERNAME = "";
 

--- a/httpclient-osgi/src/test/java/org/apache/http/osgi/impl/OSGiProxyConfigurationTest.java
+++ b/httpclient-osgi/src/test/java/org/apache/http/osgi/impl/OSGiProxyConfigurationTest.java
@@ -43,7 +43,7 @@ public class OSGiProxyConfigurationTest {
         config.put("proxy.enabled", false);
         config.put("proxy.host", "h");
         config.put("proxy.port", 1);
-        config.put("proxy.username", "u");
+        config.put("proxy.user", "u");
         config.put("proxy.password", "p");
         config.put("proxy.exceptions", new String[]{"e"});
 

--- a/httpclient-osgi/src/test/java/org/apache/http/osgi/impl/TestOSGiHttpRoutePlanner.java
+++ b/httpclient-osgi/src/test/java/org/apache/http/osgi/impl/TestOSGiHttpRoutePlanner.java
@@ -1,0 +1,163 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.osgi.impl;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.osgi.services.ProxyConfiguration;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+
+
+/**
+ * @since 4.4.3
+ */
+
+@SuppressWarnings({"nls", "javadoc"})
+public class TestOSGiHttpRoutePlanner
+{
+        final ProxyConfiguration pc1 = new ProxyConfiguration() {
+            @Override
+            public boolean isEnabled() {return true; }
+            @Override
+            public String getHostname() {return "proxy1"; }
+            @Override
+            public int getPort() { return 8080; }
+            @Override
+            public String getUsername() { return ""; }
+            @Override
+            public String getPassword() {return ""; }
+            @Override
+            public String[] getProxyExceptions() { return new String[]{"localhost", "127.0.0.1", ".apache.org"}; }
+        };
+        final ProxyConfiguration pc2 = new ProxyConfiguration() {
+            @Override
+            public boolean isEnabled() {return true; }
+            @Override
+            public String getHostname() {return "proxy2"; }
+            @Override
+            public int getPort() { return 9090; }
+            @Override
+            public String getUsername() { return ""; }
+            @Override
+            public String getPassword() {return ""; }
+            @Override
+            public String[] getProxyExceptions() { return new String[]{"localhost", "127.0.0.1", ".oracle.com", "12.34.34.8"}; }
+        };
+
+    @Test
+    public void testDeterminProxy() throws HttpException, UnknownHostException
+    {
+        final ServiceReference sRef1 = mock(ServiceReference.class);
+        final ServiceRegistration sReg1 = mock(ServiceRegistration.class);
+        when(sReg1.getReference()).thenReturn(sRef1);
+        final BundleContext bc = mock(BundleContext.class);
+        when(bc.getService(sRef1)).thenReturn(this.pc1);
+
+        final Map<String, ServiceRegistration> registrations = new TreeMap<String, ServiceRegistration>(); // TreeMap for order
+        registrations.put("foo1", sReg1);
+
+        OSGiHttpRoutePlanner planner = new OSGiHttpRoutePlanner(bc, registrations);
+
+        HttpHost proxy = planner.determineProxy(new HttpHost("localhost", 8090), null, null);
+        assertNull(proxy);
+
+        proxy = planner.determineProxy(new HttpHost("there", 9090), null, null);
+        assertNotNull(proxy);
+        assertTrue(proxy.getHostName().equals("proxy1"));
+
+        proxy = planner.determineProxy(new HttpHost("10.2.144.23", 4554), null, null);
+        assertNotNull(proxy);
+        assertTrue(proxy.getHostName().equals("proxy1"));
+
+        final InetAddress addr = InetAddress.getByName("localhost");
+        proxy = planner.determineProxy(new HttpHost(addr, 4554), null, null);
+        assertNull(proxy);
+
+        proxy = planner.determineProxy(new HttpHost("hc.apache.org", 4554), null, null);
+        assertNull(proxy);
+
+
+        // test with more than one registration of proxyConfiguration
+        final ServiceReference sRef2 = mock(ServiceReference.class);
+        final ServiceRegistration sReg2 = mock(ServiceRegistration.class);
+        when(sReg2.getReference()).thenReturn(sRef2);
+        when(bc.getService(sRef2)).thenReturn(this.pc2);
+        registrations.put("foo2", sReg2);
+
+        planner = new OSGiHttpRoutePlanner(bc, registrations);
+        proxy = planner.determineProxy(new HttpHost("localhost", 8090), null, null);
+        assertNull(proxy);
+
+        proxy = planner.determineProxy(new HttpHost("there", 9090), null, null);
+        assertNotNull(proxy);
+        assertTrue(proxy.getHostName().equals("proxy1")); // the first one
+
+        proxy = planner.determineProxy(new HttpHost(addr, 4554), null, null);
+        assertNull(proxy);
+
+        proxy = planner.determineProxy(new HttpHost("hc.apache.org", 4554), null, null);
+        assertNull(proxy);
+
+        proxy = planner.determineProxy(new HttpHost("docs.oracle.com", 4554), null, null);
+        assertNull(proxy);
+    }
+
+    @Test
+    public void testMasking() throws HttpException
+    {
+        final ServiceReference sRef2 = mock(ServiceReference.class);
+        final ServiceRegistration sReg2 = mock(ServiceRegistration.class);
+        when(sReg2.getReference()).thenReturn(sRef2);
+        final BundleContext bc = mock(BundleContext.class);
+        when(bc.getService(sRef2)).thenReturn(this.pc2);
+        final Map<String, ServiceRegistration> registrations = new TreeMap<String, ServiceRegistration>();
+        registrations.put("foo2", sReg2);
+
+        final OSGiHttpRoutePlanner planner = new OSGiHttpRoutePlanner(bc, registrations);
+
+        HttpHost proxy = planner.determineProxy(new HttpHost("12.34.34.2", 4554), null, null);
+        assertNotNull(proxy);
+        assertTrue(proxy.getHostName().equals("proxy2"));
+
+        proxy = planner.determineProxy(new HttpHost("12.34.34.8", 4554), null, null);
+        assertNotNull(proxy);
+    }
+}


### PR DESCRIPTION
Also in case there are more than one ProxyConfiguration services registered, the proxy from the first enabled one encountered will be used. From the user perspective, they have no control over which one that is. The whole idea of multiple ProxyConfigurations (its a factory) seems largely unsupported at this time.