### PR TITLE
make constructor of Content public

### DIFF
--- a/fluent-hc/src/main/java/org/apache/http/client/fluent/Content.java
+++ b/fluent-hc/src/main/java/org/apache/http/client/fluent/Content.java
@@ -44,7 +44,7 @@ public class Content {
     private final byte[] raw;
     private final ContentType type;
 
-    Content(final byte[] raw, final ContentType type) {
+    public Content(final byte[] raw, final ContentType type) {
         super();
         this.raw = raw;
         this.type = type;


### PR DESCRIPTION
I'm creating my own ResponseHandler when using the fluent API and would like to return a Content object. The Content constructor is private to the package and I'd rather not have to put my response handler into the fluent package. My best alternative right now is copy the Content class. It would be much nicer if this handy little class was updated.