### PR TITLE
HTTPCLIENT-1767: Null pointer dereference in EofSensorInputStream and ResponseEntityProxy

### DIFF
--- a/httpclient/src/main/java/org/apache/http/conn/EofSensorInputStream.java
+++ b/httpclient/src/main/java/org/apache/http/conn/EofSensorInputStream.java
@@ -197,9 +197,8 @@ public class EofSensorInputStream extends InputStream implements ConnectionRelea
         if ((toCheckStream != null) && (eof < 0)) {
             try {
                 boolean scws = true; // should close wrapped stream?
-                final EofSensorWatcher toCheckWatcher = eofWatcher;
-                if (toCheckWatcher != null) {
-                    scws = toCheckWatcher.eofDetected(toCheckStream);
+                if (eofWatcher != null) {
+                    scws = eofWatcher.eofDetected(toCheckStream);
                 }
                 if (scws) {
                     toCheckStream.close();
@@ -227,9 +226,8 @@ public class EofSensorInputStream extends InputStream implements ConnectionRelea
         if (toCloseStream != null) {
             try {
                 boolean scws = true; // should close wrapped stream?
-                final EofSensorWatcher toCloseWatcher = eofWatcher;
-                if (toCloseWatcher != null) {
-                    scws = toCloseWatcher.streamClosed(toCloseStream);
+                if (eofWatcher != null) {
+                    scws = eofWatcher.streamClosed(toCloseStream);
                 }
                 if (scws) {
                     toCloseStream.close();
@@ -259,9 +257,8 @@ public class EofSensorInputStream extends InputStream implements ConnectionRelea
         if (toAbortStream != null) {
             try {
                 boolean scws = true; // should close wrapped stream?
-                final EofSensorWatcher toAbortWatcher = eofWatcher;
-                if (toAbortWatcher != null) {
-                    scws = toAbortWatcher.streamAbort(toAbortStream);
+                if (eofWatcher != null) {
+                    scws = eofWatcher.streamAbort(toAbortStream);
                 }
                 if (scws) {
                     toAbortStream.close();

--- a/httpclient/src/main/java/org/apache/http/conn/EofSensorInputStream.java
+++ b/httpclient/src/main/java/org/apache/http/conn/EofSensorInputStream.java
@@ -193,14 +193,16 @@ public class EofSensorInputStream extends InputStream implements ConnectionRelea
      */
     protected void checkEOF(final int eof) throws IOException {
 
-        if ((wrappedStream != null) && (eof < 0)) {
+        final InputStream toCheckStream = wrappedStream;
+        if ((toCheckStream != null) && (eof < 0)) {
             try {
                 boolean scws = true; // should close wrapped stream?
-                if (eofWatcher != null) {
-                    scws = eofWatcher.eofDetected(wrappedStream);
+                final EofSensorWatcher toCheckWatcher = eofWatcher;
+                if (toCheckWatcher != null) {
+                    scws = toCheckWatcher.eofDetected(toCheckStream);
                 }
                 if (scws) {
-                    wrappedStream.close();
+                    toCheckStream.close();
                 }
             } finally {
                 wrappedStream = null;
@@ -221,14 +223,16 @@ public class EofSensorInputStream extends InputStream implements ConnectionRelea
      */
     protected void checkClose() throws IOException {
 
-        if (wrappedStream != null) {
+        final InputStream toCloseStream = wrappedStream;
+        if (toCloseStream != null) {
             try {
                 boolean scws = true; // should close wrapped stream?
-                if (eofWatcher != null) {
-                    scws = eofWatcher.streamClosed(wrappedStream);
+                final EofSensorWatcher toCloseWatcher = eofWatcher;
+                if (toCloseWatcher != null) {
+                    scws = toCloseWatcher.streamClosed(toCloseStream);
                 }
                 if (scws) {
-                    wrappedStream.close();
+                    toCloseStream.close();
                 }
             } finally {
                 wrappedStream = null;
@@ -251,14 +255,16 @@ public class EofSensorInputStream extends InputStream implements ConnectionRelea
      */
     protected void checkAbort() throws IOException {
 
-        if (wrappedStream != null) {
+        final InputStream toAbortStream = wrappedStream;
+        if (toAbortStream != null) {
             try {
                 boolean scws = true; // should close wrapped stream?
-                if (eofWatcher != null) {
-                    scws = eofWatcher.streamAbort(wrappedStream);
+                final EofSensorWatcher toAbortWatcher = eofWatcher;
+                if (toAbortWatcher != null) {
+                    scws = toAbortWatcher.streamAbort(toAbortStream);
                 }
                 if (scws) {
-                    wrappedStream.close();
+                    toAbortStream.close();
                 }
             } finally {
                 wrappedStream = null;

--- a/httpclient/src/main/java/org/apache/http/impl/execchain/ResponseEntityProxy.java
+++ b/httpclient/src/main/java/org/apache/http/impl/execchain/ResponseEntityProxy.java
@@ -98,7 +98,9 @@ class ResponseEntityProxy extends HttpEntityWrapper implements EofSensorWatcher 
     @Override
     public void writeTo(final OutputStream outstream) throws IOException {
         try {
-            this.wrappedEntity.writeTo(outstream);
+            if (outstream != null) {
+                this.wrappedEntity.writeTo(outstream);
+            }
             releaseConnection();
         } catch (final IOException ex) {
             abortConnection();
@@ -116,7 +118,9 @@ class ResponseEntityProxy extends HttpEntityWrapper implements EofSensorWatcher 
         try {
             // there may be some cleanup required, such as
             // reading trailers after the response body:
-            wrapped.close();
+            if (wrapped != null) {
+                wrapped.close();
+            }
             releaseConnection();
         } catch (final IOException ex) {
             abortConnection();
@@ -137,7 +141,9 @@ class ResponseEntityProxy extends HttpEntityWrapper implements EofSensorWatcher 
             // this assumes that closing the stream will
             // consume the remainder of the response body:
             try {
-                wrapped.close();
+                if(wrapped != null) {
+                    wrapped.close();
+                }
                 releaseConnection();
             } catch (final SocketException ex) {
                 if (open) {

--- a/httpclient/src/main/java/org/apache/http/impl/execchain/ResponseEntityProxy.java
+++ b/httpclient/src/main/java/org/apache/http/impl/execchain/ResponseEntityProxy.java
@@ -141,7 +141,7 @@ class ResponseEntityProxy extends HttpEntityWrapper implements EofSensorWatcher 
             // this assumes that closing the stream will
             // consume the remainder of the response body:
             try {
-                if(wrapped != null) {
+                if (wrapped != null) {
                     wrapped.close();
                 }
                 releaseConnection();


### PR DESCRIPTION
This fixes HTTPCLIENT-1767 by adding null checks to ResponseEntityProxy and dereferencing instance variables before null checks in EofSensorInputStream.

For reference here, the stacktrace, against httpclient-4.5.2, which I can't reproduce reliably, but which should be fixed by these changes is:

```
java.lang.NullPointerException: null
	at org.apache.http.impl.execchain.ResponseEntityProxy.streamClosed(ResponseEntityProxy.java:140)
	at org.apache.http.conn.EofSensorInputStream.checkClose(EofSensorInputStream.java:228)
	at org.apache.http.conn.EofSensorInputStream.close(EofSensorInputStream.java:174)
```