### PR TITLE
[HTTPCLIENT-1810] URIBuilder.toString() always adds '/' to path, even with query parameters

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
@@ -26,17 +26,17 @@
  */
 package org.apache.http.client.utils;
 
+import org.apache.http.Consts;
+import org.apache.http.NameValuePair;
+import org.apache.http.conn.util.InetAddressUtils;
+import org.apache.http.message.BasicNameValuePair;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import org.apache.http.Consts;
-import org.apache.http.NameValuePair;
-import org.apache.http.conn.util.InetAddressUtils;
-import org.apache.http.message.BasicNameValuePair;
 
 /**
  * Builder for {@link URI} instances.
@@ -492,8 +492,8 @@ public class URIBuilder {
 
     private static String normalizePath(final String path) {
         String s = path;
-        if (s == null) {
-            return "/";
+        if (s == null || "".equals(s)) {
+            return "";
         }
         int n = 0;
         for (; n < s.length(); n++) {

--- a/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
@@ -26,17 +26,18 @@
  */
 package org.apache.http.client.utils;
 
-import org.apache.http.Consts;
-import org.apache.http.NameValuePair;
-import org.apache.http.conn.util.InetAddressUtils;
-import org.apache.http.message.BasicNameValuePair;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
+import org.apache.http.Consts;
+import org.apache.http.NameValuePair;
+import org.apache.http.conn.util.InetAddressUtils;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.TextUtils;
 
 /**
  * Builder for {@link URI} instances.
@@ -492,7 +493,7 @@ public class URIBuilder {
 
     private static String normalizePath(final String path) {
         String s = path;
-        if (s == null || "".equals(s)) {
+        if (TextUtils.isBlank(s)) {
             return "";
         }
         int n = 0;


### PR DESCRIPTION
When path is null or '', URIBuilder. normalizePath() should return '' rather than '/'.