### PR TITLE
HTTPCLIENT-1830: await termination of the IdleConnectionEvictor when it is shut down

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
@@ -507,7 +507,8 @@ public class HttpAsyncClientBuilder {
             if (evictExpiredConnections || evictIdleConnections) {
                 if (connManagerCopy instanceof ConnPoolControl) {
                     final IdleConnectionEvictor connectionEvictor = new IdleConnectionEvictor((ConnPoolControl<?>) connManagerCopy,
-                            maxIdleTime > 0 ? maxIdleTime : 10, maxIdleTimeUnit != null ? maxIdleTimeUnit : TimeUnit.SECONDS);
+                            maxIdleTime > 0 ? maxIdleTime : 10, maxIdleTimeUnit != null ? maxIdleTimeUnit : TimeUnit.SECONDS,
+                            maxIdleTime, maxIdleTimeUnit);
                     closeablesCopy.add(new Closeable() {
 
                         @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
@@ -513,8 +513,12 @@ public class HttpAsyncClientBuilder {
                         @Override
                         public void close() throws IOException {
                             connectionEvictor.shutdown();
+                            try {
+                                connectionEvictor.awaitTermination(1, TimeUnit.SECONDS);
+                            } catch (InterruptedException interrupted) {
+                                Thread.currentThread().interrupt();
+                            }
                         }
-
                     });
                     connectionEvictor.start();
                 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/sync/HttpClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/sync/HttpClientBuilder.java
@@ -871,8 +871,12 @@ public class HttpClientBuilder {
                         @Override
                         public void close() throws IOException {
                             connectionEvictor.shutdown();
+                            try {
+                                connectionEvictor.awaitTermination(1, TimeUnit.SECONDS);
+                            } catch (InterruptedException interrupted) {
+                                Thread.currentThread().interrupt();
+                            }
                         }
-
                     });
                     connectionEvictor.start();
                 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/sync/HttpClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/sync/HttpClientBuilder.java
@@ -865,7 +865,8 @@ public class HttpClientBuilder {
             if (evictExpiredConnections || evictIdleConnections) {
                 if (connManagerCopy instanceof ConnPoolControl) {
                     final IdleConnectionEvictor connectionEvictor = new IdleConnectionEvictor((ConnPoolControl<?>) connManagerCopy,
-                            maxIdleTime > 0 ? maxIdleTime : 10, maxIdleTimeUnit != null ? maxIdleTimeUnit : TimeUnit.SECONDS);
+                            maxIdleTime > 0 ? maxIdleTime : 10, maxIdleTimeUnit != null ? maxIdleTimeUnit : TimeUnit.SECONDS,
+                            maxIdleTime, maxIdleTimeUnit);
                     closeablesCopy.add(new Closeable() {
 
                         @Override


### PR DESCRIPTION
See [HTTPCLIENT-1830](https://issues.apache.org/jira/browse/HTTPCLIENT-1830) for more details.

I also noticed something weird with the original implementation of this in [HTTPCLIENT-1583](https://issues.apache.org/jira/browse/HTTPCLIENT-1583) that I think means that `HttpClientBuilder.evictExpiredConnections` is not working as intended, see my comment on that ticket.