### PR TITLE
HTTPCLIENT-1835: evictExpiredConnections no longer causes the evictIleConnections behaviour to be enabled when evictIdleConnections is not explicitly enabled (4.6.x)

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/client/HttpClientBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/HttpClientBuilder.java
@@ -1209,7 +1209,8 @@ public class HttpClientBuilder {
 
             if (evictExpiredConnections || evictIdleConnections) {
                 final IdleConnectionEvictor connectionEvictor = new IdleConnectionEvictor(cm,
-                        maxIdleTime > 0 ? maxIdleTime : 10, maxIdleTimeUnit != null ? maxIdleTimeUnit : TimeUnit.SECONDS);
+                        maxIdleTime > 0 ? maxIdleTime : 10, maxIdleTimeUnit != null ? maxIdleTimeUnit : TimeUnit.SECONDS,
+                        maxIdleTime, maxIdleTimeUnit);
                 closeablesCopy.add(new Closeable() {
 
                     @Override


### PR DESCRIPTION
Same as #70 but for 4.6.x