### PR TITLE
Add Brotli support

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseContentEncoding.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseContentEncoding.java
@@ -46,6 +46,7 @@ import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.message.BasicHeaderValueParser;
 import org.apache.hc.core5.http.message.ParserCursor;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.brotli.dec.BrotliInputStream;
 
 /**
  * {@link HttpResponseInterceptor} responsible for processing Content-Encoding
@@ -75,6 +76,15 @@ public class ResponseContentEncoding implements HttpResponseInterceptor {
         }
 
     };
+    
+    private final static InputStreamFactory BROTLI = new InputStreamFactory() {
+
+        @Override
+        public InputStream create(final InputStream instream) throws IOException {
+            return new BrotliInputStream(instream);
+        }
+
+    };
 
     private final Lookup<InputStreamFactory> decoderRegistry;
     private final boolean ignoreUnknown;
@@ -88,6 +98,7 @@ public class ResponseContentEncoding implements HttpResponseInterceptor {
                     .register("gzip", GZIP)
                     .register("x-gzip", GZIP)
                     .register("deflate", DEFLATE)
+                    .register("br", BROTLI)
                     .build();
         this.ignoreUnknown = ignoreUnknown;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <httpcore.version>5.0-alpha2</httpcore.version>
     <log4j.version>2.8</log4j.version>
+    <dec.version>0.1.1</dec.version>
     <commons-codec.version>1.10</commons-codec.version>
     <ehcache.version>2.6.11</ehcache.version>
     <memcached.version>2.12.0</memcached.version>
@@ -108,6 +109,11 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.brotli</groupId>
+        <artifactId>dec</artifactId>
+        <version>${dec.version}</version>
       </dependency>
       <dependency>
         <groupId>net.sf.ehcache</groupId>


### PR DESCRIPTION
This PR adds support of Brotli decoding to HC.
It relies on https://github.com/google/brotli/tree/master/java/org/brotli which is under MIT license.

Regards
@philmdot